### PR TITLE
generate types for materialized view

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -142,6 +142,7 @@ export class Generator {
       .with("base table", () => "Table" as const)
       .with("table", () => "Table" as const)
       .with("view", () => "View" as const)
+      .with("materialized view", () => "View" as const)
       .otherwise(() => null);
   }
 


### PR DESCRIPTION
We can treat Postgres' [materialized view](https://www.postgresql.org/docs/current/rules-materializedviews.html) the same as a regular view.

ts-sql-codgen currently skips it:
> Unknown table type MATERIALIZED VIEW for table public.my_materialized_view: SKIPPING
